### PR TITLE
Declare the book's packages; make packages.R work headless

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: placeholder
 Type: Book
 Title: Does not matter.
-Version: 0.6.0
+Version: 0.6.1
 Date: 2026-08-05
 Imports: bookdown
 Remotes: rstudio/bookdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# fish_passage_fraser_2025_reporting 0.6.1 (2026-08-05)
+
+* Declare everything the book loads in `scripts/packages.R`. `leafpop` (interactive map popups), `english` (inline prose), `bcmaps` (UAV appendix) and `cd` (climate departure appendix) were used in rendered chunks but declared nowhere, so a fresh clone could not build. Also set a CRAN mirror when the session has none — `Rscript` starts with `repos` unset, which made the pak check fail outright while RStudio masked it — and read `params$update_packages` defensively, since several scripts source this file before defining `params` ([Issue #30](https://github.com/NewGraphEnvironment/fish_passage_fraser_2025_reporting/issues/30))
+
 # fish_passage_fraser_2025_reporting 0.6.0 (2026-08-05)
 
 * Build the provincial Fish Data Submission workbook for the 2025 habitat confirmations, at `data/permit_submission/PG25-983997.xlsx` under scientific fish collection permit PG25-983997, with DFO licence XR 463 2025. No fish were sampled, so the submission carries site locations and habitat measurements only and Steps 2 and 3 are empty. Ports the workflow from Peace 2025 rather than the reporting template, which is a generation behind and writes CSVs for manual copy-paste-special ([Issue #26](https://github.com/NewGraphEnvironment/fish_passage_fraser_2025_reporting/issues/26))

--- a/index.Rmd
+++ b/index.Rmd
@@ -15,7 +15,7 @@ author: |
 
 date: |
  |
- | Version 0.6.0 DRAFT `r format(Sys.Date(), "%Y-%m-%d")`
+ | Version 0.6.1 DRAFT `r format(Sys.Date(), "%Y-%m-%d")`
  |
  | *Claude Opus 5 (Anthropic) assisted with literature synthesis, drafting, and technical writing. All scientific interpretation, data analysis, and conclusions are the responsibility of the authors.*
 toc-title: Table of Contents

--- a/scripts/packages.R
+++ b/scripts/packages.R
@@ -1,8 +1,21 @@
-# ensure pak is installed and up to date from CRAN
+# A session started by Rscript has no repository set (`@CRAN@`), which makes
+# install.packages() and available.packages() below fail outright. RStudio sets a
+# mirror for you, so this only ever bites headless builds.
+if (!nzchar(getOption("repos")[[1]]) || identical(unname(getOption("repos")[[1]]), "@CRAN@")) {
+  options(repos = c(CRAN = "https://cloud.r-project.org"))
+}
+
+# Several scripts source this file BEFORE they define `params` - see
+# 01_prep_inputs/0220_fish_data_tidy.R, which sources on line 2 and reads the
+# report front matter on line 7. Read it defensively so that still works.
+update_packages <- isTRUE(tryCatch(params$update_packages, error = function(e) FALSE))
+
+# ensure pak is installed, and up to date from CRAN when we are already updating
 if (!requireNamespace("pak", quietly = TRUE)) {
   install.packages("pak")
-} else {
-  # Only run this if an update is needed
+} else if (update_packages) {
+  # available.packages() is a network round trip, and it used to run on every
+  # source() of this file rather than only when updating.
   current <- packageVersion("pak")
   latest <- package_version(available.packages()["pak", "Version"])
   if (current < latest) {
@@ -30,7 +43,13 @@ pkgs_cran <- c(
   "terra",
   "maptiles",
   "png",
-  "stars"
+  "stars",
+  # popupTable()/popupImage() on the interactive maps - 0400-results.Rmd
+  "leafpop",
+  # as.english()/ordinal() in inline prose - 0400-results.Rmd, site appendices
+  "english",
+  # bc_bound() - 0740-appendix-uav-imagery.Rmd
+  "bcmaps"
 )
 
 pkgs_gh <- c(
@@ -41,6 +60,8 @@ pkgs_gh <- c(
   "newgraphenvironment/gq",
   "newgraphenvironment/fresh",
   "newgraphenvironment/flooded",
+  # climate departure appendix - 0710-appendix-climate-departure.Rmd
+  "newgraphenvironment/cd",
   "newgraphenvironment/staticimports",
   "newgraphenvironment/fishbc@updated_data",
   "poissonconsulting/readwritesqlite", #https://github.com/poissonconsulting/readwritesqlite/issues/47
@@ -52,8 +73,7 @@ pkgs_all <- c(pkgs_cran,
 
 
 # install or upgrade all the packages with pak
-# install or upgrade all the packages with pak
-if(params$update_packages){
+if (update_packages) {
   lapply(pkgs_all, pak::pkg_install, ask = FALSE)
 }
 


### PR DESCRIPTION
## Summary

Declares everything the book loads in `scripts/packages.R`, and makes the file work in a headless session.

Building v0.6.0 from a clean `Rscript` failed four separate times, each on a different missing package. `leafpop`, `english`, `bcmaps` and `cd` are used in chunks that render into the book but were declared in neither `pkgs_cran` nor `pkgs_gh` — a fresh clone could not build.

| Package | Used by |
|---|---|
| `leafpop` | `0400-results.Rmd` — `popupTable()` / `popupImage()` |
| `english` | `0400-results.Rmd`, site appendices — `as.english()` / `ordinal()` |
| `bcmaps` | `0740-appendix-uav-imagery.Rmd` — `bc_bound()` |
| `cd` | `0710-appendix-climate-departure.Rmd` — `cd_summary()`, `cd_plot_timeseries()` |

Two further problems in the same file, both masked by RStudio and only biting headless builds:

- **No CRAN mirror.** `Rscript` starts with `repos` unset (`@CRAN@`), so `available.packages()` failed with *"trying to use CRAN without setting a mirror"*. Now set when the session has none.
- **`params` read before it exists.** `0220_fish_data_tidy.R` sources `packages.R` on line 2 and defines `params` on line 7, so a clean run errored with *"object 'params' not found"*. Now read defensively.

The pak self-update also reached out to CRAN on **every** `source()` of this file — nine scripts and Rmds source it — rather than only when updating. Now gated on `update_packages`.

## Verification

Sourced headless with no `repos` and no `params` — the exact case that was broken:

```
repos at start: @CRAN@
params exists: FALSE
source() errored: FALSE
repos after: https://cloud.r-project.org
  leafpop  attached=TRUE
  english  attached=TRUE
  bcmaps   attached=TRUE
  cd       attached=TRUE
```

## Note

`scripts/packages.R` has already drifted across the fish passage repos — template, Peace 2025 and Fraser 2025 all differ, and all three are missing these same declarations. This fix should travel with the template back-port after Skeena 2025 rather than being applied piecemeal.

`mapview` is also undeclared but only used in `scripts/tutorials/road_tenure.Rmd`, which is not part of the book — left alone.

Fixes #30
Relates to NewGraphEnvironment/sred#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019191dRnbx32ESpSZq7xqzF
